### PR TITLE
modify setXXX() impl in FlushableMemoryBlock.java

### DIFF
--- a/src/main/java/lib/llpl/FlushableMemoryBlock.java
+++ b/src/main/java/lib/llpl/FlushableMemoryBlock.java
@@ -76,21 +76,21 @@ class FlushableMemoryBlock extends MemoryBlock<Flushable> {
     @Override
     public void setByte(long offset, byte value) {
         markDirty();
-        setRawLong(offset, value);
+        setRawByte(offset, value);
         addToMemoryRanges(offset, Byte.BYTES);
     }
 
     @Override
     public void setShort(long offset, short value) {
         markDirty();
-        setRawLong(offset, value);
+        setRawShort(offset, value);
         addToMemoryRanges(offset, Short.BYTES);
     }
 
     @Override
     public void setInt(long offset, int value) {
         markDirty();
-        setRawLong(offset, value);
+        setRawInt(offset, value);
         addToMemoryRanges(offset, Integer.BYTES);
     }
 

--- a/src/test/java/lib/llpl/TransactionTest.java
+++ b/src/test/java/lib/llpl/TransactionTest.java
@@ -14,6 +14,7 @@ class TransactionTest {
 
         // thread-local syntax
         Transaction.run(h, () -> {
+            // Maybe addToTransaction() is required?
             block1.setLong(4, 1000);
             block1.setInt(0, 777);
             assert(block1.getLong(4)) == 1000;


### PR DESCRIPTION
Hi, I'm confused why you call SetRawLong() for any setXXX() in  FlushableMemoryBlock.java.

In addition, when in transaction, I think pmemobj_tx_add_range() is required to take a snapshot of the modified regions. So in case of failure, the regions can be rolled back.