### PR TITLE
Typo on ExceptionInInitializerError message

### DIFF
--- a/src/main/java/com/intel/pmem/llpl/Util.java
+++ b/src/main/java/com/intel/pmem/llpl/Util.java
@@ -68,7 +68,7 @@ public class Util {
             loaded = true;
         } 
         catch (IOException e) {
-            throw new ExceptionInInitializerError("Failed to native load llpl library");
+            throw new ExceptionInInitializerError("Failed to load native llpl library");
         }
         finally {
             if (nativeLib != null) nativeLib.deleteOnExit();


### PR DESCRIPTION
Small typo on the message of the `ExceptionInInitializerError`.